### PR TITLE
Fetch all jobs endpoint

### DIFF
--- a/src/controllers/api.js
+++ b/src/controllers/api.js
@@ -8,6 +8,33 @@ const { DateTime } = require('luxon');
 
 module.exports = {
   /**
+   * Fetches all jobs from the system and returns then in this endpoint. If
+   * there are no jobs, an empty array is returned.
+   *
+   * @param {JBRequest} req
+   * @param {JBResponse} res
+   */
+  async fetchAllJobs(req, res) {
+    const allJobs = await req.ModelFactory.job.fetchAllJobs(
+      req.ModelFactory,
+      req.DaoFactory
+    );
+    // console.log(allJobs);
+    return res.status(200).json(
+      allJobs.map((job) => ({
+        id: job.id,
+        title: job.title,
+        location: job.location,
+        salary: job.salary,
+        jobType: job.jobType,
+        summary: job.summary,
+        description: job.description,
+        datePosted: job.datePosted,
+      }))
+    );
+  },
+
+  /**
    * Assuming the request body contains valid job details, this function creates
    * a new job and returns a 201. If any of the provided job details are invalid
    * a 400 response is provided. A 500 if there is an unexpected system issue.

--- a/src/daos/job.js
+++ b/src/daos/job.js
@@ -40,7 +40,7 @@ class JobDao {
       jobType: jobRow.job_type,
       summary: jobRow.summary,
       description: jobRow.description,
-      datePosted: DateTime.fromSQL(jobRow.date_posted),
+      datePosted: DateTime.fromJSDate(jobRow.date_posted),
     };
   }
 
@@ -80,7 +80,7 @@ class JobDao {
       job_type: jobPayload.jobType,
       summary: jobPayload.summary,
       description: jobPayload.description,
-      date_posted: jobPayload.datePosted.toSQL(),
+      date_posted: jobPayload.datePosted.toJSDate(),
     });
     return this._JobRowtoJobData(jobRow);
   }

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -3,6 +3,7 @@ const apiController = require('../controllers/api');
 
 const router = express.Router();
 
+router.get('/jobs', apiController.fetchAllJobs);
 router.post('/jobs', apiController.createJob);
 
 module.exports = router;

--- a/src/stores/job.js
+++ b/src/stores/job.js
@@ -4,6 +4,10 @@
  */
 
 /**
+ * Date columns are automatically converted to JS Date objects by the
+ * node-postgres library:
+ * https://node-postgres.com/features/types#date-timestamp-timestamptz
+ *
  * @typedef {object} JobRow
  * @property {number} [id] - Optional for new rows
  * @property {string} title
@@ -12,9 +16,9 @@
  * @property {string} job_type
  * @property {string} summary
  * @property {string} description
- * @property {string} date_posted - SQL datetime
- * @property {string} [created_time] - SQL datetime, Optional for new rows
- * @property {string} [updated_time] - SQL datetime, Optional for new rows
+ * @property {Date} date_posted - SQL datetime
+ * @property {Date} [created_time] - SQL datetime, Optional for new rows
+ * @property {Date} [updated_time] - SQL datetime, Optional for new rows
  */
 
 class JobStore {

--- a/test/controllers/api.spec.js
+++ b/test/controllers/api.spec.js
@@ -4,6 +4,85 @@ const sinon = require('sinon');
 const apiController = require('../../src/controllers/api');
 
 describe('Controller: api', function () {
+  describe('fetchAllJobs', function () {
+    it('responds with an empty array when there are no jobs', async function () {
+      const mockStatus = sinon.stub();
+      const mockJson = sinon.stub();
+
+      const mockRequest = {
+        ModelFactory: {
+          job: {
+            fetchAllJobs: sinon.stub().resolves([]),
+          },
+        },
+      };
+      const mockResponse = {
+        status: mockStatus.returns({
+          json: mockJson,
+        }),
+      };
+
+      await apiController.fetchAllJobs(mockRequest, mockResponse);
+
+      assert.equal(mockStatus.getCall(0).args[0], 200);
+
+      assert.isArray(mockJson.getCall(0).args[0]);
+    });
+    it('jobs have the correct properties', async function () {
+      const mockStatus = sinon.stub();
+      const mockJson = sinon.stub();
+
+      const mockRequest = {
+        ModelFactory: {
+          job: {
+            fetchAllJobs: sinon.stub().resolves([
+              {
+                id: '1',
+                title: '2',
+                location: '3',
+                salary: '4',
+                jobType: '5',
+                summary: '6',
+                description: '7',
+                datePosted: '8',
+              },
+            ]),
+          },
+        },
+      };
+      const mockResponse = {
+        status: mockStatus.returns({
+          json: mockJson,
+        }),
+      };
+
+      await apiController.fetchAllJobs(mockRequest, mockResponse);
+
+      assert.equal(mockStatus.getCall(0).args[0], 200);
+
+      assert.deepEqual(Object.keys(mockJson.getCall(0).args[0][0]), [
+        'id',
+        'title',
+        'location',
+        'salary',
+        'jobType',
+        'summary',
+        'description',
+        'datePosted',
+      ]);
+
+      // Test that the correct properties are mapped to the correct job 
+      // attributes.
+      assert.equal(mockJson.getCall(0).args[0][0].id, 1);
+      assert.equal(mockJson.getCall(0).args[0][0].title, 2);
+      assert.equal(mockJson.getCall(0).args[0][0].location, 3);
+      assert.equal(mockJson.getCall(0).args[0][0].salary, 4);
+      assert.equal(mockJson.getCall(0).args[0][0].jobType, 5);
+      assert.equal(mockJson.getCall(0).args[0][0].summary, 6);
+      assert.equal(mockJson.getCall(0).args[0][0].description, 7);
+      assert.equal(mockJson.getCall(0).args[0][0].datePosted, 8);
+    });
+  });
   describe('createJob', function () {
     // TODO: Test each of input parameters
     it('returns 400 when some data is missing from the POST request', async function () {

--- a/test/daos/job.spec.js
+++ b/test/daos/job.spec.js
@@ -112,7 +112,7 @@ describe('Dao: Job', function () {
         job_type: '4',
         summary: '5',
         description: '6',
-        date_posted: mockDate.toSQL(),
+        date_posted: mockDate.toJSDate(),
       });
     });
   });


### PR DESCRIPTION
Fixes #14 

Adds endpoint to fetch all jobs. Also fixes a bug with the dates coming from the store.

Details of the bug:
The `JobData` objects that the DAO works in expect the `datePosted` property to be a Luxon date object. The store has a method for normalising the data from the database into these dates. My original assumption was that the data coming from the database would be a date string. It turns out, the dates coming back were vanilla `Date` objects. This meant that Luxon was failing to parse them as I was giving it a different format to the one it was expecting. The code has now been updated and a comment added to explain why they are coming back as vanilla `Date` objects from the store.